### PR TITLE
Optimize parser.minify()

### DIFF
--- a/test/emberjson/test_json.mojo
+++ b/test/emberjson/test_json.mojo
@@ -11,7 +11,7 @@ fn files_enabled() -> Bool:
 
 def test_minify():
     assert_equal(
-        minify('{"key": 123, "k": [123, false, [1, 2, 3]]}'),
+        minify('{"key"\r\n: \t123\n, "k": \r\t[123, false, [1, \r2,   3]]}'),
         '{"key":123,"k":[123,false,[1,2,3]]}',
     )
 


### PR DESCRIPTION
### Before

| name              | met (ms)           | iters | DataMovement (GB/s) | min (ms)           | mean (ms)          | max (ms)           | duration (ms) |
|--|--|--|--|--|--|--|--|
| MinifyCitmCatalog | 2.5500578139534884 | 473   | 0.6773195456781528  | 2.5500578139534884 | 2.5500578139534884 | 2.5500578139534884 | 1206.177346   |


### After

| name              | met (ms)           | iters | DataMovement (GB/s) | min (ms)           | mean (ms)          | max (ms)           | duration (ms) |
|--|--|--|--|--|--|--|--|
| MinifyCitmCatalog | 1.5828126287339972 | 703   | 1.0912245509321552  | 1.5828126287339972 | 1.5828126287339972 | 1.5828126287339972 | 1112.717278   |