### PR TITLE
Optimize pretty print

### DIFF
--- a/bench.mojo
+++ b/bench.mojo
@@ -120,7 +120,6 @@ fn main() raises:
     run[benchmark_pretty_print, "WritePrettyCitmCatalog"](m, parse(catalog))
     run[benchmark_pretty_print, "WritePrettyTwitter"](m, parse(twitter))
 
-
     m.dump_report()
 
 

--- a/emberjson/array.mojo
+++ b/emberjson/array.mojo
@@ -143,16 +143,17 @@ struct Array(Sized, JsonValue):
 
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         writer.write("[\n")
         self._pretty_write_items(writer, indent, curr_depth + 1)
         writer.write("]")
 
     fn _pretty_write_items[
         W: Writer
-    ](self, mut writer: W, indent: String, curr_depth: Int):
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
         for i in range(len(self._data)):
-            writer.write(indent * curr_depth)
+            for _ in range(curr_depth):
+                writer.write(indent)
             self._data[i]._pretty_to_as_element(writer, indent, curr_depth)
             if i < len(self._data) - 1:
                 writer.write(",")

--- a/emberjson/json.mojo
+++ b/emberjson/json.mojo
@@ -154,7 +154,7 @@ struct JSON(JsonValue, Sized):
 
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         """Write the pretty representation to a writer.
 
         Args:

--- a/emberjson/object.mojo
+++ b/emberjson/object.mojo
@@ -112,17 +112,19 @@ struct Object(Sized, JsonValue):
 
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         writer.write("{\n")
         self._pretty_write_items(writer, indent, curr_depth + 1)
         writer.write("}")
 
     fn _pretty_write_items[
         W: Writer
-    ](self, mut writer: W, indent: String, curr_depth: Int):
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
         var done = 0
         for item in self._data:
-            writer.write(indent * curr_depth, '"', item[].key, '"', ": ")
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write('"', item[].key, '"', ": ")
             item[].data._pretty_to_as_element(writer, indent, curr_depth)
             if done < len(self._data) - 1:
                 writer.write(",")

--- a/emberjson/parser.mojo
+++ b/emberjson/parser.mojo
@@ -441,9 +441,7 @@ struct Parser[origin: Origin[False], options: ParseOptions = ParseOptions()]:
             p += 1
 
             var first_after_period = p
-            if p.dist() >= 8 and is_made_of_eight_digits_fast(
-                p.p
-            ):
+            if p.dist() >= 8 and is_made_of_eight_digits_fast(p.p):
                 i = i * 100000000 + parse_eight_digits(p.p)
                 p += 8
             while parse_digit(p, i):

--- a/emberjson/traits.mojo
+++ b/emberjson/traits.mojo
@@ -1,7 +1,7 @@
 trait PrettyPrintable:
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         ...
 
 

--- a/emberjson/value.mojo
+++ b/emberjson/value.mojo
@@ -52,7 +52,7 @@ struct Null(JsonValue):
     @always_inline
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         writer.write(self)
 
 
@@ -329,21 +329,25 @@ struct Value(JsonValue):
 
     fn _pretty_to_as_element[
         W: Writer
-    ](self, mut writer: W, indent: String, curr_depth: Int):
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
         if self.isa[Object]():
             writer.write("{\n")
             self.object()._pretty_write_items(writer, indent, curr_depth + 1)
-            writer.write(indent * curr_depth, "}")
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write("}")
         elif self.isa[Array]():
             writer.write("[\n")
             self.array()._pretty_write_items(writer, indent, curr_depth + 1)
-            writer.write(indent * curr_depth, "]")
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write("]")
         else:
             self.write_to(writer)
 
     fn pretty_to[
         W: Writer
-    ](self, mut writer: W, indent: String, *, curr_depth: Int = 0):
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
         if self.isa[Object]():
             self.object().pretty_to(writer, indent, curr_depth=curr_depth)
         elif self.isa[Array]():


### PR DESCRIPTION
Optimize pretty print. Mostly by avoiding allocations and optimizing the writer method to precalculate the total byte size


### Before
| name                   | met (ms)          | iters | DataMovement (GB/s)  | min (ms)          | mean (ms)         | max (ms)          | duration (ms) |
|-|-|-|-|-|-|-|-|
| WritePrettyCitmCatalog | 8.186376739726027 | 146   | 0.061113605677613064 | 8.186376739726027 | 8.186376739726027 | 8.186376739726027 | 1195.211004   |
| WritePrettyTwitter     | 1.32933839        | 800   | 0.3512318635437889   | 1.32933839        | 1.32933839        | 1.32933839        | 1063.470712   |

### After
| name                   | met (ms)          | iters | DataMovement (GB/s) | min (ms)           | mean (ms)         | max (ms)           | duration (ms) |
|-|-|-|-|-|-|-|-|
| WritePrettyCitmCatalog | 4.647730640926641 | 259   | 0.10764371661182434 | 4.647730640926641  | 4.647730640926641 | 4.647730640926641  | 1203.762236   |
| WritePrettyTwitter     | 1.059446347       | 1000  | 0.4407075462784148  | 1.0594463470000002 | 1.059446347       | 1.0594463470000002 | 1059.446347   |