### PR TITLE
[stdlib] Add Raw types and tests (lazy parsing)

### DIFF
--- a/emberjson/__init__.mojo
+++ b/emberjson/__init__.mojo
@@ -6,6 +6,17 @@ from .utils import write, write_pretty
 from .parser import Parser, ParseOptions, minify
 
 
+from .lazy import (
+    RawJSON,
+    RawArray,
+    RawObject,
+    RawValue,
+    RawJsonType,
+    RawParser,
+    RawParseOptions,
+)
+
+
 @always_inline
 fn parse[options: ParseOptions = ParseOptions()](out j: JSON, s: String) raises:
     """Parses a JSON object from a String.

--- a/emberjson/lazy/__init__.mojo
+++ b/emberjson/lazy/__init__.mojo
@@ -1,0 +1,5 @@
+from .raw_json import RawJSON
+from .raw_array import RawArray
+from .raw_object import RawObject
+from .raw_value import RawValue, RawJsonType
+from .raw_parser import RawParser, RawParseOptions

--- a/emberjson/lazy/raw_array.mojo
+++ b/emberjson/lazy/raw_array.mojo
@@ -1,0 +1,204 @@
+from memory import UnsafePointer
+from python import PythonObject, Python
+
+from .raw_parser import RawParser
+from .raw_value import RawValue
+from emberjson.traits import JsonValue
+
+
+@register_passable("trivial")
+struct _RawArrayIter[
+    mut: Bool, //,
+    values_origin: ImmutableOrigin,
+    array_origin: Origin[mut],
+    forward: Bool = True,
+](Sized, Copyable, Movable):
+    var index: Int
+    var src: Pointer[RawArray[values_origin], array_origin]
+
+    fn __init__(out self, src: Pointer[RawArray[values_origin], array_origin]):
+        self.src = src
+
+        @parameter
+        if forward:
+            self.index = 0
+        else:
+            self.index = len(self.src[])
+
+    fn __iter__(self) -> Self:
+        return self
+
+    fn __next__(
+        mut self, out p: Pointer[RawValue[values_origin], array_origin]
+    ):
+        @parameter
+        if not forward:
+            self.index -= 1
+
+        p = Pointer(to=self.src[].__getitem__(self.index))
+
+        @parameter
+        if forward:
+            self.index += 1
+
+    fn __has_next__(self) -> Bool:
+        return len(self) > 0
+
+    fn __len__(self) -> Int:
+        @parameter
+        if forward:
+            return len(self.src[]) - self.index
+        else:
+            return self.index
+
+
+struct RawArray[origin: ImmutableOrigin](Sized, JsonValue):
+    """Represents a heterogeneous array of json types.
+
+    This is accomplished by using `RawValue` for the collection type, which
+    is essentially a variant type of the possible valid json types.
+    """
+
+    alias Type = List[RawValue[origin]]
+    var _data: Self.Type
+
+    @always_inline
+    fn __init__(out self):
+        self._data = Self.Type()
+
+    @always_inline
+    fn __init__(out self, *, capacity: Int):
+        self._data = Self.Type(capacity=capacity)
+
+    @always_inline
+    @implicit
+    fn __init__(out self, owned d: Self.Type):
+        self._data = d^
+
+    @always_inline
+    fn __init__(
+        out self, owned *values: RawValue[origin], __list_literal__: () = ()
+    ):
+        self._data = Self.Type(elements=values^)
+
+    @always_inline
+    fn __init__(out self, *, parse_string: StringSlice[origin]) raises:
+        var p = RawParser[origin](parse_string)
+        self = p.parse_array()
+
+    @always_inline
+    fn __copyinit__(out self, other: Self):
+        self._data = other._data
+
+    @always_inline
+    fn copy(self) -> Self:
+        return self
+
+    @always_inline
+    fn __moveinit__(out self, owned other: Self):
+        self._data = other._data^
+
+    @always_inline
+    fn __getitem__[
+        T: Indexer
+    ](ref self, ind: T) -> ref [__origin_of(self)] RawValue[origin]:
+        return UnsafePointer(to=self._data[ind]).origin_cast[
+            mut = Origin(__origin_of(self)).mut, origin = __origin_of(self)
+        ]()[]
+
+    @always_inline
+    fn __setitem__[T: Indexer](mut self, ind: T, owned item: RawValue[origin]):
+        self._data[ind] = item^
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return len(self._data)
+
+    @always_inline
+    fn __bool__(self) -> Bool:
+        return len(self) == 0
+
+    @always_inline
+    fn __as_bool__(self) -> Bool:
+        return Bool(self)
+
+    @always_inline
+    fn __contains__(self, v: RawValue[origin]) -> Bool:
+        return v in self._data
+
+    @always_inline
+    fn __eq__(self, other: Self) -> Bool:
+        return self._data == other._data
+
+    @always_inline
+    fn __ne__(self, other: Self) -> Bool:
+        return self._data != other._data
+
+    @always_inline
+    fn __iter__(
+        ref self,
+    ) -> _RawArrayIter[values_origin=origin, array_origin = __origin_of(self)]:
+        return _RawArrayIter(Pointer(to=self))
+
+    @always_inline
+    fn reversed(
+        ref self,
+    ) -> _RawArrayIter[
+        values_origin=origin, array_origin = __origin_of(self), forward=False
+    ]:
+        return _RawArrayIter[forward=False](Pointer(to=self))
+
+    @always_inline
+    fn iter(
+        ref self,
+    ) -> _RawArrayIter[values_origin=origin, array_origin = __origin_of(self)]:
+        return self.__iter__()
+
+    @always_inline
+    fn reserve(mut self, n: Int):
+        self._data.reserve(n)
+
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write("[")
+        for i in range(len(self._data)):
+            writer.write(self._data[i])
+            if i != len(self._data) - 1:
+                writer.write(",")
+        writer.write("]")
+
+    fn pretty_to[
+        W: Writer
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
+        writer.write("[\n")
+        self._pretty_write_items(writer, indent, curr_depth + 1)
+        writer.write("]")
+
+    fn _pretty_write_items[
+        W: Writer
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
+        for i in range(len(self._data)):
+            for _ in range(curr_depth):
+                writer.write(indent)
+            self._data[i]._pretty_to_as_element(writer, indent, curr_depth)
+            if i < len(self._data) - 1:
+                writer.write(",")
+            writer.write("\n")
+
+    @always_inline
+    fn __str__(self) -> String:
+        return write(self)
+
+    @always_inline
+    fn __repr__(self) -> String:
+        return self.__str__()
+
+    @always_inline
+    fn append(mut self, owned item: RawValue[origin]):
+        self._data.append(item^)
+
+    fn to_list(owned self, out l: List[RawValue[origin]]):
+        l = self._data^
+        __disable_del self
+
+    fn to_python_object(self) -> PythonObject:
+        return Python.list(self._data)

--- a/emberjson/lazy/raw_json.mojo
+++ b/emberjson/lazy/raw_json.mojo
@@ -1,0 +1,243 @@
+from utils import Variant
+from sys.intrinsics import unlikely
+from os import abort
+from python import PythonObject
+
+from .raw_array import RawArray
+from .raw_object import RawObject
+from .raw_parser import RawParser
+from .raw_value import RawValue
+from emberjson.traits import JsonValue
+from emberjson.utils import write, ByteView
+
+
+struct RawJSON[origin: ImmutableOrigin](JsonValue, Sized):
+    """Top level JSON object, can either be a RawArray, or a RawObject."""
+
+    alias Type = Variant[RawObject[origin], RawArray[origin]]
+    var _data: Self.Type
+
+    @always_inline
+    fn __init__(out self):
+        self._data = RawObject[origin]()
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned ob: RawObject[origin]):
+        self._data = ob^
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned arr: RawArray[origin]):
+        self._data = arr^
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned l: RawArray[origin].Type):
+        self._data = l^
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned o: RawObject[origin].Type):
+        self._data = o^
+
+    @always_inline
+    fn __init__(out self, *, parse_bytes: Span[Byte, origin]) raises:
+        """Parse JSON document from bytes.
+
+        Args:
+            parse_bytes: The bytes to parse.
+
+        Raises:
+            If the bytes represent an invalid JSON document.
+        """
+        var parser = RawParser[origin](parse_bytes)
+        self = parser.parse()
+
+    @always_inline
+    fn __init__(out self, *, ref [origin]parse_string: String) raises:
+        """Parse JSON document from a string.
+
+        Args:
+            parse_string: The string to parse.
+
+        Raises:
+            If the string represents an invalid JSON document.
+        """
+        self = Self(parse_bytes=parse_string.as_bytes())
+
+    @always_inline
+    fn __copyinit__(out self, other: Self):
+        self._data = other._data
+
+    @always_inline
+    fn __moveinit__(out self, owned other: Self):
+        self._data = other._data^
+
+    @always_inline
+    fn copy(self) -> Self:
+        return self
+
+    @always_inline
+    fn object(ref self) -> RawObject[origin]:
+        """Fetch the inner object of this json document.
+
+        Returns:
+            A reference to a JSON object.
+        """
+        return self._data[RawObject[origin]]
+
+    @always_inline
+    fn array(ref self) -> RawArray[origin]:
+        """Fetch the inner array of this json document.
+
+        Returns:
+            A reference to a JSON array.
+        """
+        return self._data[RawArray[origin]]
+
+    fn __contains__(self, v: RawValue[origin]) raises -> Bool:
+        """Check if the given value exists in the document.
+
+        Raises:
+            If a non-string value is used on an object.
+
+        Returns:
+            True if the value is a value within the array or is a key in the object.
+        """
+        if self.is_array():
+            return v in self.array()
+        if not v.is_string():
+            raise Error("expected string key")
+        return v.string() in self.object()
+
+    fn _type_equal(self, other: Self) -> Bool:
+        return self._data._get_discr() == other._data._get_discr()
+
+    fn __eq__(self, other: Self) -> Bool:
+        """Checks if this document is equal to another.
+
+        Returns:
+            True if the document is of same type and value as other else False.
+        """
+        if not self._type_equal(other):
+            return False
+        elif self.is_object():
+            return self.object() == other.object()
+        elif self.is_array():
+            return self.array() == other.array()
+        abort("unreachable")
+        return False
+
+    @always_inline
+    fn __ne__(self, other: Self) -> Bool:
+        """Checks if this document is not equal to another.
+
+        Returns:
+            True if the document is not of same type and value as other else False.
+        """
+        return not self == other
+
+    @always_inline
+    fn __len__(self) -> Int:
+        """Returns the length of the inner value. This will be the number of items
+        in an array, or the number of keys in an object.
+
+        Returns:
+            The length of the inner container.
+        """
+        return len(self.array()) if self.is_array() else len(self.object())
+
+    @always_inline
+    fn __bool__(self) -> Bool:
+        """Returns True if the size of the inner collection is non-empty.
+
+        Return:
+            True if the inner container is non-empty else False
+        """
+        return len(self) == 0
+
+    @always_inline
+    fn __as_bool__(self) -> Bool:
+        """Returns True if the size of the inner collection is non-empty.
+
+        Return:
+            True if the inner container is non-empty else False
+        """
+        return Bool(self)
+
+    @always_inline
+    fn write_to[W: Writer](self, mut writer: W):
+        """Writes the string representation of the document to the given writer.
+
+        Args:
+            writer: A writer to write to.
+        """
+        if self.is_object():
+            writer.write(self.object())
+        else:
+            writer.write(self.array())
+
+    fn pretty_to[
+        W: Writer
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
+        """Write the pretty representation to a writer.
+
+        Args:
+            writer: The writer to write to.
+            indent: If an int denotes the number of space characters to use,
+                    if a string then use the given string to indent.
+            curr_depth: The current depth into the json document, controls the
+                    current level of indendation.
+        """
+        if self.is_object():
+            self.object().pretty_to(writer, indent, curr_depth=curr_depth)
+        else:
+            self.array().pretty_to(writer, indent, curr_depth=curr_depth)
+
+    @always_inline
+    fn __str__(self) -> String:
+        """Returns the json string repr of the document.
+
+        Returns:
+            A json string.
+        """
+        return write(self)
+
+    @always_inline
+    fn __repr__(self) -> String:
+        """Returns the json string repr of the document.
+
+        Returns:
+            A json string.
+        """
+        return self.__str__()
+
+    @always_inline
+    fn isa[T: Movable & Copyable](self) -> Bool:
+        return self._data.isa[T]()
+
+    @always_inline
+    fn is_object(self) -> Bool:
+        """Check if the inner value is an object.
+
+        Returns:
+            True if the inner value is an object else False.
+        """
+        return self.isa[RawObject[origin]]()
+
+    @always_inline
+    fn is_array(self) -> Bool:
+        """Check if the inner value is an array.
+
+        Returns:
+            True if the inner value is an array else False.
+        """
+        return self.isa[RawArray[origin]]()
+
+    fn to_python_object(self) -> PythonObject:
+        return (
+            self.array()
+            .to_python_object() if self.is_array() else self.object()
+            .to_python_object()
+        )

--- a/emberjson/lazy/raw_object.mojo
+++ b/emberjson/lazy/raw_object.mojo
@@ -1,0 +1,173 @@
+from collections import Dict
+from sys.intrinsics import unlikely, likely
+from python import PythonObject, Python
+from os import abort
+
+from .raw_value import RawValue
+from .raw_tree import _RawTreeKeyIter, _RawTreeIter, _RawTreeValueIter, RawTree
+from .raw_parser import RawParser
+from emberjson.traits import JsonValue
+
+
+struct RawObject[origin: ImmutableOrigin](Sized, JsonValue):
+    """Represents a key-value pair object.
+    All keys are String and all values are of type `RawValue` which is
+    a variant type of any valid JSON type.
+    """
+
+    alias Type = RawTree[origin]
+    var _data: Self.Type
+
+    alias ObjectIter = _RawTreeIter[origin]
+    alias ObjectKeyIter = _RawTreeKeyIter[origin]
+    alias ObjectValueIter = _RawTreeValueIter[origin]
+
+    @always_inline
+    fn __init__(out self):
+        self._data = Self.Type()
+
+    @always_inline
+    @implicit
+    fn __init__(out self, owned d: Self.Type):
+        self._data = d^
+
+    @always_inline
+    @implicit
+    fn __init__(out self, d: Dict[String, RawValue[origin]]):
+        self._data = Self.Type()
+        for item in d.items():
+            self._data.insert(item[].key, item[].value)
+
+    fn __init__(
+        out self,
+        owned keys: List[String],
+        owned values: List[RawValue[origin]],
+        __dict_literal__: (),
+    ):
+        debug_assert(len(keys) == len(values))
+        self._data = Self.Type()
+        for i in range(len(keys)):
+            self._data.insert(keys[i], values[i])
+
+    @always_inline
+    fn __init__(out self, *, parse_string: StringSlice[origin]) raises:
+        var p = RawParser(parse_string)
+        self = p.parse_object()
+
+    @always_inline
+    fn __copyinit__(out self, other: Self):
+        self._data = other._data
+
+    @always_inline
+    fn __moveinit__(out self, owned other: Self):
+        self._data = other._data^
+
+    @always_inline
+    fn copy(self) -> Self:
+        return self
+
+    @always_inline
+    fn __setitem__(mut self, owned key: String, owned item: RawValue[origin]):
+        self._data[key^] = item^
+
+    @always_inline
+    fn __getitem__(ref self, key: String) raises -> RawValue[origin]:
+        return self._data.__getitem__(key)
+
+    @always_inline
+    fn __contains__(self, key: String) -> Bool:
+        return key in self._data
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return len(self._data)
+
+    fn __eq__(self, other: Self) -> Bool:
+        if len(self) != len(other):
+            return False
+
+        for k in self._data.keys():
+            if k[] not in other:
+                return False
+            try:
+                if self[k[]] != other[k[]]:
+                    return False
+            except:
+                return False
+        return True
+
+    @always_inline
+    fn __ne__(self, other: Self) -> Bool:
+        return not self == other
+
+    @always_inline
+    fn __bool__(self) -> Bool:
+        return len(self) == 0
+
+    @always_inline
+    fn __as_bool__(self) -> Bool:
+        return Bool(self)
+
+    @always_inline
+    fn keys(ref self) -> Self.ObjectKeyIter:
+        return self._data.keys()
+
+    @always_inline
+    fn values(ref self) -> Self.ObjectValueIter:
+        return self._data.values()
+
+    @always_inline
+    fn __iter__(ref self) -> Self.ObjectKeyIter:
+        return self.keys()
+
+    @always_inline
+    fn items(ref self) -> Self.ObjectIter:
+        return self._data.items()
+
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write(self._data)
+
+    fn pretty_to[
+        W: Writer
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
+        writer.write("{\n")
+        self._pretty_write_items(writer, indent, curr_depth + 1)
+        writer.write("}")
+
+    fn _pretty_write_items[
+        W: Writer
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
+        var done = 0
+        for item in self._data:
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write('"', item[].key, '"', ": ")
+            item[].data._pretty_to_as_element(writer, indent, curr_depth)
+            if done < len(self._data) - 1:
+                writer.write(",")
+            writer.write("\n")
+            done += 1
+
+    @always_inline
+    fn __str__(self) -> String:
+        return write(self)
+
+    @always_inline
+    fn __repr__(self) -> String:
+        return self.__str__()
+
+    @always_inline
+    fn to_dict(owned self, out d: Dict[String, RawValue[origin]]):
+        d = Dict[String, RawValue[origin]]()
+        for item in self.items():
+            d[item[].key] = item[].data
+
+    fn to_python_object(self) -> PythonObject:
+        try:
+            var d = Python.dict()
+            for item in self.items():
+                d[item[].key] = item[].data.to_python_object()
+            return d
+        except:
+            abort("Unexpected error: Failed to convert object to python dict")
+        return None

--- a/emberjson/lazy/raw_parser.mojo
+++ b/emberjson/lazy/raw_parser.mojo
@@ -1,0 +1,462 @@
+from bit import count_trailing_zeros
+from memory import UnsafePointer, memset
+from sys.intrinsics import unlikely, likely
+from collections import InlineArray
+from memory.unsafe import bitcast
+from bit import count_leading_zeros
+from sys.compile import is_compile_time
+
+
+from .raw_array import RawArray
+from .raw_object import RawObject
+from .raw_json import RawJSON
+from .raw_value import RawValue, RawJsonType
+
+from emberjson.utils import to_string, is_space
+from emberjson.simd import SIMD8_WIDTH, SIMD8xT
+from emberjson._parser_helper import (
+    copy_to_string,
+    TRUE,
+    ALSE,
+    NULL,
+    StringBlock,
+    is_numerical_component,
+    get_non_space_bits,
+    smallest_power,
+    to_double,
+    parse_digit,
+    ptr_dist,
+    significant_digits,
+    unsafe_is_made_of_eight_digits_fast,
+    unsafe_parse_eight_digits,
+    largest_power,
+    is_exp_char,
+    pack_into_integer,
+)
+from emberjson.tables import (
+    power_of_ten,
+    full_multiplication,
+    power_of_five_128,
+)
+from emberjson.constants import (
+    `[`,
+    `]`,
+    `{`,
+    `}`,
+    `,`,
+    `"`,
+    `:`,
+    `t`,
+    `f`,
+    `n`,
+    `u`,
+    acceptable_escapes,
+    `\\`,
+    `\n`,
+    `\r`,
+    `\t`,
+    `-`,
+    `+`,
+    `0`,
+    `9`,
+    `.`,
+    ` `,
+    `1`,
+)
+
+#######################################################
+# Certain parts inspired/taken from SonicCPP and simdjon
+# https://github.com/bytedance/sonic-cpp
+# https://github.com/simdjson/simdjson
+#######################################################
+
+
+struct RawParseOptions(Copyable, Movable):
+    """JSON parsing options.
+
+    Fields:
+        ignore_unicode: Do not decode escaped unicode characters for a slight
+            increase in performance.
+    """
+
+    var ignore_unicode: Bool
+
+    fn __init__(out self, *, ignore_unicode: Bool = False):
+        self.ignore_unicode = ignore_unicode
+
+
+struct RawParser[
+    origin: ImmutableOrigin, options: RawParseOptions = RawParseOptions()
+](Sized):
+    var data: Span[Byte, origin]
+    """The raw data that the parser parses."""
+    var idx: UInt
+    """The index at which the parser points to."""
+
+    fn __init__(out self, ref [origin]s: String):
+        self = __type_of(self)(ptr=s.unsafe_ptr(), length=s.byte_length())
+
+    fn __init__(out self, s: StringSlice[origin], idx: UInt = 0):
+        self = Self(ptr=s.unsafe_ptr(), length=s.byte_length(), idx=idx)
+
+    fn __init__(out self, s: Span[Byte, origin], idx: UInt = 0):
+        self = Self(ptr=s.unsafe_ptr(), length=len(s), idx=idx)
+
+    fn __init__(
+        out self,
+        *,
+        ptr: UnsafePointer[Byte, mut=False, origin=origin, **_],
+        length: UInt,
+        idx: UInt = 0,
+    ):
+        # FIXME: temporary rebind
+        self.data = Span[Byte, ptr.origin](
+            ptr=rebind[UnsafePointer[Byte]](ptr), length=length
+        )
+        self.idx = idx
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return len(self.data) - 1 - self.idx
+
+    @always_inline
+    fn has_more(self) -> Bool:
+        return len(self.data) - 1 > self.idx
+
+    @always_inline
+    fn remaining(self) -> String:
+        """Used for debug purposes.
+
+        Returns:
+            A string containing the remaining unprocessed data from parser
+            input.
+        """
+        try:
+            var span = self.data[Int(self.idx) :]
+            var ptr = span.unsafe_ptr()
+            return copy_to_string[True](ptr, ptr + len(span))
+        except:
+            return ""
+
+    @always_inline
+    fn load_chunk(self) -> SIMD8xT:
+        var ptr = self.data.unsafe_ptr()
+        if len(self) < SIMD8_WIDTH:
+            v = SIMD8xT(0)
+            for i in range(len(self)):
+                v[i] = ptr[i]
+            return v
+        return ptr.load[width=SIMD8_WIDTH]()
+
+    @always_inline
+    fn can_load_chunk(self) -> Bool:
+        return len(self) >= SIMD8_WIDTH
+
+    fn parse(mut self, out json: RawJSON[origin]) raises:
+        self.skip_whitespace()
+        if likely(self.has_more()):
+            var b = self.data.unsafe_ptr()[self.idx]
+            if b == `[`:
+                json = self.parse_array()
+                return
+            elif b == `{`:
+                json = self.parse_object()
+                return
+        raise Error("Invalid json")
+
+    fn parse_array(mut self, out arr: RawArray[origin]) raises:
+        self.idx += 1
+        self.skip_whitespace()
+        arr = RawArray[origin]()
+        var ptr = self.data.unsafe_ptr()
+        var has_comma = False
+
+        while ptr[self.idx] != `]` and likely(self.has_more()):
+            arr.append(self.parse_value())
+            self.skip_whitespace()
+            has_comma = ptr[self.idx] == `,`
+            self.idx += Int(has_comma and likely(self.has_more()))
+
+        if unlikely(has_comma):
+            raise Error("Illegal trailing comma")
+        if unlikely(ptr[self.idx] != `]`):
+            raise Error("Expected ']'")
+
+        self.idx += 1
+
+    fn parse_object(mut self, out obj: RawObject[origin]) raises:
+        obj = RawObject[origin]()
+        self.idx += 1
+        self.skip_whitespace()
+        var ptr = self.data.unsafe_ptr()
+
+        if unlikely(ptr[self.idx] != `}`):
+            while True:
+                if unlikely(ptr[self.idx] != `"`):
+                    raise Error("Invalid identifier")
+                var ident = RawValue(self._read_string()).string()
+                self.skip_whitespace()
+                if unlikely(ptr[self.idx] != `:`):
+                    raise Error("Invalid identifier : ", self.remaining())
+                self.idx += 1
+                var value = self.parse_value()
+                self.skip_whitespace()
+                var has_comma = False
+                if ptr[self.idx] == `,`:
+                    self.idx += 1
+                    self.skip_whitespace()
+                    has_comma = True
+                obj[ident] = value^
+                if ptr[self.idx] == `}`:
+                    if has_comma:
+                        raise Error("Illegal trailing comma")
+                    break
+                if unlikely(len(self) == 0):
+                    raise Error("Expected '}'")
+
+        self.idx += 1
+
+    fn parse_value(mut self, out v: RawValue[origin]) raises:
+        self.skip_whitespace()
+        var ptr = self.data.unsafe_ptr()
+        var b = ptr[self.idx]
+        # Handle string
+        if b == `"`:
+            v = self._read_string()
+
+        # Handle "true" atom
+        elif b == `t`:
+            if unlikely(len(self) < 3):
+                raise Error('Encountered EOF when expecting "true"')
+            # Safety: Safe because we checked the amount of bytes remaining
+            var w = (ptr + self.idx).bitcast[UInt32]()[0]
+            if w != TRUE:
+                raise Error("Expected 'true', received: ", to_string(w))
+            v = RawValue(
+                json_type=RawJsonType.TRUE,
+                span=self.data[Int(self.idx) : Int(self.idx) + 4],
+            )
+            self.idx += 4
+
+        # handle "false" atom
+        elif b == `f`:
+            self.idx += 1
+            if unlikely(len(self) < 3):
+                raise Error('Encountered EOF when expecting "false"')
+            # Safety: Safe because we checked the amount of bytes remaining
+            var w = (ptr + self.idx).bitcast[UInt32]()[0]
+            if w != ALSE:
+                raise Error("Expected 'false', received: f", to_string(w))
+            v = RawValue(
+                json_type=RawJsonType.FALSE,
+                span=self.data[Int(self.idx) - 1 : Int(self.idx) + 4],
+            )
+            self.idx += 4
+
+        # handle "null" atom
+        elif b == `n`:
+            if unlikely(len(self) < 3):
+                raise Error('Encountered EOF when expecting "null"')
+            # Safety: Safe because we checked the amount of bytes remaining
+            var w = (ptr + self.idx).bitcast[UInt32]()[0]
+            if w != NULL:
+                raise Error("Expected 'null', received: ", to_string(w))
+            v = RawValue(
+                json_type=RawJsonType.NULL,
+                span=self.data[Int(self.idx) : Int(self.idx) + 4],
+            )
+            self.idx += 4
+
+        # handle object
+        elif b == `{`:
+            v = self.parse_object()
+
+        # handle array
+        elif b == `[`:
+            v = self.parse_array()
+
+        # handle number
+        elif is_numerical_component(b):
+            v = self.parse_number()
+        else:
+            raise Error("Invalid json value: ", self.remaining())
+
+    fn _skip_escaped_chars(
+        mut self, start: UInt, out s: StringSlice[origin]
+    ) raises:
+        debug_assert(self.has_more(), "Should have values to iterate")
+        self.idx += 1
+        var ptr = self.data.unsafe_ptr()
+        if ptr[self.idx] == `\\`:
+            debug_assert(self.has_more(), "unescaped value")
+            debug_assert(
+                ptr[self.idx + 1] in acceptable_escapes,
+                "Value cannot be escaped: ",
+                StringSlice[origin](ptr=ptr + self.idx, length=1),
+            )
+            return self._skip_escaped_chars(start)
+        return self._find_quote(start)
+
+    fn _find_quote(mut self, start: UInt, out s: StringSlice[origin]) raises:
+        var ptr = self.data.unsafe_ptr()
+        var block = StringBlock.find(ptr + self.idx)
+        if block.has_quote_first():
+            self.idx += UInt(block.quote_index())
+            return StringSlice[ptr.origin](
+                ptr=ptr + start, length=self.idx - start
+            )
+        elif unlikely(not self.has_more()):
+            # We got EOF before finding the end quote, so obviously this
+            # input is malformed
+            raise Error("Unexpected EOF")
+
+        if unlikely(block.has_unescaped()):
+            raise Error(
+                "Control characters must be escaped: ",
+                to_string(self.load_chunk()),
+                " : ",
+                String(block.unescaped_index()),
+            )
+        if not block.has_backslash():
+            self.idx += SIMD8_WIDTH
+            return self._find_quote(start)
+        self.idx += UInt(block.bs_index())
+        return self._skip_escaped_chars(start)
+
+    fn _read_string(mut self, out s: StringSlice[origin]) raises:
+        self.idx += 1
+        var ptr = self.data.unsafe_ptr()
+        if ptr[self.idx] == `"`:  # ""
+            s = StringSlice[origin](ptr=ptr + self.idx, length=0)
+            self.idx += 1
+            return
+        var start = self.idx
+        var escaped = False
+        while likely(self.has_more()):
+            self.idx += 1
+            # compile time interpreter is incompatible with the SIMD accelerated
+            # path, so fallback to the serial implementation
+            if self.can_load_chunk() and not is_compile_time():
+                s = self._find_quote(start)
+                self.idx += 1
+                return
+            elif likely(not escaped) and ptr[self.idx] == `"`:
+                s = StringSlice[origin](
+                    ptr=ptr + start, length=self.idx - start
+                )
+                self.idx += 1
+                return
+            escaped = ptr[self.idx] == `\\`
+        raise Error("Invalid String")
+
+    @always_inline
+    fn skip_whitespace(mut self) raises:
+        var ptr = self.data.unsafe_ptr()
+        if not self.has_more() or not is_space(ptr[self.idx]):
+            return
+        self.idx += 1
+
+        # compile time interpreter is incompatible with the SIMD accelerated
+        # path, so fallback to the serial implementation
+        while self.can_load_chunk() and not is_compile_time():
+            var chunk = self.load_chunk()
+            var nonspace = get_non_space_bits(chunk)
+            if nonspace != 0:
+                self.idx += UInt(count_trailing_zeros(nonspace))
+                return
+            else:
+                self.idx += SIMD8_WIDTH
+
+        while self.has_more() and is_space(ptr[self.idx]):
+            self.idx += 1
+
+    #####################################################################################################################
+    # BASED ON SIMDJSON https://github.com/simdjson/simdjson/blob/master/include/simdjson/generic/numberparsing.h
+    #####################################################################################################################
+
+    @always_inline
+    fn compute_float_fast(
+        self, out d: Float64, power: Int64, i: UInt64, negative: Bool
+    ):
+        d = Float64(i)
+        var pow: Float64
+        var neg_power = power < 0
+
+        # TODO: Remove this branch after `power_of_ten` is also ctime computed again
+        if is_compile_time():
+            pow = 10.0 ** Float64(abs(power))
+        else:
+            pow = power_of_ten.unsafe_get(Int(abs(power)))
+
+        d = d / pow if neg_power else d * pow
+        if negative:
+            d = -d
+
+    @always_inline
+    fn parse_number(mut self, out v: RawValue[origin]) raises:
+        var ptr = self.data.unsafe_ptr()
+        var start = self.idx
+        var neg = ptr[self.idx] == `-`
+        self.idx += Int(neg or ptr[self.idx] == `+`)
+        if unlikely(not self.has_more() and start != self.idx):
+            raise Error("Invalid number: sign only")
+        var starts_with_zero = ptr[self.idx] == `0`
+
+        while `0` <= ptr[self.idx] <= `9` and likely(self.has_more()):
+            self.idx += 1
+
+        if unlikely(starts_with_zero and self.idx > start + 1):
+            raise Error("Invalid number: starts with zero")
+
+        var has_dot = ptr[self.idx] == `.`
+
+        if has_dot and self.has_more():
+            self.idx += 1
+
+            if len(self) >= 8:
+                self.idx += (7 + Int(self.has_more())) & -Int(
+                    unsafe_is_made_of_eight_digits_fast(ptr + self.idx)
+                )
+
+            while `0` <= ptr[self.idx] <= `9` and likely(self.has_more()):
+                self.idx += 1
+
+        if is_exp_char(ptr[self.idx]):
+            if unlikely(not self.has_more()):
+                raise Error("Invalid float: Exponent followed by no number")
+            self.idx += 1
+
+            var neg_exp = ptr[self.idx] == `-`
+            var has_sign = neg_exp or ptr[self.idx] == `+`
+            self.idx += Int(has_sign and likely(self.has_more()))
+
+            if unlikely(not (`0` <= ptr[self.idx] <= `9`)):
+                raise Error("Invalid float: Sign followed by no number")
+
+            while `0` <= ptr[self.idx] <= `9` and likely(self.has_more()):
+                self.idx += 1
+
+            self.idx += 1
+            v = RawValue(
+                json_type=RawJsonType.FLOAT_EXP,
+                span=Span[Byte, origin](
+                    ptr=ptr + start, length=self.idx - start
+                ),
+            )
+            return
+
+        self.idx += Int(`0` <= ptr[self.idx] <= `9`)
+        if has_dot:
+            v = RawValue(
+                json_type=RawJsonType.FLOAT_DOT,
+                span=Span[Byte, origin](
+                    ptr=ptr + start, length=self.idx - start
+                ),
+            )
+        else:
+            v = RawValue(
+                json_type=RawJsonType.INT,
+                span=Span[Byte, origin](
+                    ptr=ptr + start, length=self.idx - start
+                ),
+            )

--- a/emberjson/lazy/raw_tree.mojo
+++ b/emberjson/lazy/raw_tree.mojo
@@ -1,0 +1,313 @@
+from memory import UnsafePointer
+from os import abort
+
+
+from .raw_value import RawValue
+
+
+struct RawTreeNode[origin: ImmutableOrigin](
+    Writable, Stringable, Representable, Copyable, Movable
+):
+    var data: RawValue[origin]
+    var key: String
+    var left: UnsafePointer[Self]
+    var right: UnsafePointer[Self]
+    var parent: UnsafePointer[Self]
+
+    fn __init__(out self, owned key: String, owned data: RawValue[origin]):
+        self.data = data^
+        self.key = key^
+        self.left = UnsafePointer[Self]()
+        self.right = UnsafePointer[Self]()
+        self.parent = UnsafePointer[Self]()
+
+    @always_inline
+    fn __eq__(self, other: Self) -> Bool:
+        return self.key == other.key
+
+    @always_inline
+    fn __lt__(self, other: Self) -> Bool:
+        return self.key < other.key
+
+    @always_inline
+    fn __gt__(self, other: Self) -> Bool:
+        return self.key > other.key
+
+    @always_inline
+    fn __str__(self) -> String:
+        return String(self)
+
+    fn __repr__(self) -> String:
+        var out = String()
+        out.write("RawTreeNode(", self.key, ", ", self.data, ")")
+        return out
+
+    @always_inline
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write('"', self.key, '"', ":", self.data)
+
+    @staticmethod
+    fn make_ptr(
+        owned key: String,
+        owned data: RawValue[origin],
+        out p: UnsafePointer[Self],
+    ):
+        p = UnsafePointer[Self].alloc(1)
+        p.init_pointee_move(RawTreeNode[origin](key^, data^))
+
+
+@fieldwise_init
+@register_passable("trivial")
+struct _RawTreeIter[origin: ImmutableOrigin](Sized, Copyable, Movable):
+    var curr: UnsafePointer[RawTreeNode[origin]]
+    var seen: Int
+    var total: Int
+
+    @always_inline
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline
+    fn __next__(mut self, out p: UnsafePointer[RawTreeNode[origin], mut=False]):
+        self.seen += 1
+        p = self.curr
+        self.curr = _get_next(self.curr)
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.seen < self.total
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return self.total
+
+
+@fieldwise_init
+@register_passable("trivial")
+struct _RawTreeKeyIter[origin: ImmutableOrigin](Sized, Copyable, Movable):
+    var curr: UnsafePointer[RawTreeNode[origin]]
+    var seen: Int
+    var total: Int
+
+    @always_inline
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline
+    fn __next__(mut self, out p: UnsafePointer[String, mut=False]):
+        self.seen += 1
+        p = UnsafePointer(to=self.curr[].key)
+        self.curr = _get_next(self.curr)
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.seen < self.total
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return self.total
+
+
+@fieldwise_init
+@register_passable("trivial")
+struct _RawTreeValueIter[origin: ImmutableOrigin](Sized, Copyable, Movable):
+    var curr: UnsafePointer[RawTreeNode[origin]]
+    var seen: Int
+    var total: Int
+
+    @always_inline
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline
+    fn __next__(mut self, out p: UnsafePointer[RawValue[origin], mut=False]):
+        self.seen += 1
+        p = UnsafePointer(to=self.curr[].data)
+        self.curr = _get_next(self.curr)
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.seen < self.total
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return self.total
+
+
+struct RawTree[origin: ImmutableOrigin](
+    Movable, Copyable, Sized, ExplicitlyCopyable, Writable, Stringable
+):
+    alias NodePtr = UnsafePointer[RawTreeNode[origin]]
+    var root: Self.NodePtr
+    var size: UInt
+
+    fn __init__(out self):
+        self.root = Self.NodePtr()
+        self.size = 0
+
+    fn __copyinit__(out self, other: Self):
+        self = self.__init__()
+        for node in other:
+            self.insert(RawTreeNode[origin].make_ptr(node[].key, node[].data))
+
+    fn copy(self) -> Self:
+        return self
+
+    fn __moveinit__(out self, owned other: Self):
+        self.root = other.root
+        self.size = other.size
+        other.root = Self.NodePtr()
+        other.size = 0
+
+    @always_inline
+    fn __iter__(self) -> _RawTreeIter[origin]:
+        return _RawTreeIter(self.get_first(), 0, self.size)
+
+    @always_inline
+    fn keys(self) -> _RawTreeKeyIter[origin]:
+        return _RawTreeKeyIter(self.get_first(), 0, self.size)
+
+    @always_inline
+    fn items(self) -> _RawTreeIter[origin]:
+        return _RawTreeIter(self.get_first(), 0, self.size)
+
+    @always_inline
+    fn values(self) -> _RawTreeValueIter[origin]:
+        return _RawTreeValueIter(self.get_first(), 0, self.size)
+
+    @always_inline
+    fn __len__(self) -> Int:
+        return self.size
+
+    fn __del__(owned self):
+        fn do_del(node: Self.NodePtr):
+            if node:
+                node.destroy_pointee()
+                node.free()
+
+        for_each[do_del](self.root)
+
+    fn get_first(self) -> Self.NodePtr:
+        if not self.root:
+            return self.root
+
+        return _get_left_most(self.root)
+
+    fn insert(mut self, node: Self.NodePtr):
+        self.size += 1
+        if not self.root:
+            self.root = node
+            return
+
+        var parent = Self.NodePtr()
+        var curr = self.root
+
+        while curr:
+            parent = curr
+            if curr[] > node[]:
+                curr = curr[].left
+            elif curr[] < node[]:
+                curr = curr[].right
+            else:
+                # we didn't actually insert a new element
+                self.size -= 1
+                curr[].data = node[].data
+                return
+
+        if parent[] > node[]:
+            node[].parent = parent
+            parent[].left = node
+        else:
+            node[].parent = parent
+            parent[].right = node
+
+    @always_inline
+    fn insert(mut self, owned key: String, owned data: RawValue[origin]):
+        self.insert(RawTreeNode[origin].make_ptr(key^, data^))
+
+    fn write_to[W: Writer](self, mut writer: W):
+        writer.write("{")
+        var written = 0
+        self.write_nodes(writer, self.root, written)
+        writer.write("}")
+
+    @always_inline
+    fn find(self, key: String) -> Self.NodePtr:
+        return _find(self.root, key)
+
+    fn __getitem__(ref self, key: String) raises -> RawValue[origin]:
+        var node = self.find(key)
+        if not node:
+            raise Error("Key error")
+        return node[].data
+
+    @always_inline
+    fn __setitem__(mut self, owned key: String, owned data: RawValue[origin]):
+        self.insert(key^, data^)
+
+    @always_inline
+    fn __contains__(self, key: String) -> Bool:
+        return Bool(self.find(key))
+
+    fn write_nodes[
+        W: Writer
+    ](self, mut writer: W, node: Self.NodePtr, mut written: Int):
+        if not node:
+            return
+
+        self.write_nodes(writer, node[].left, written)
+
+        writer.write(node[])
+        if written < self.size - 1:
+            writer.write(",")
+        written += 1
+
+        self.write_nodes(writer, node[].right, written)
+
+    @always_inline
+    fn __str__(self) -> String:
+        return String(self)
+
+
+########################################################################
+# Utilities
+########################################################################
+
+
+fn for_each[
+    origin: ImmutableOrigin, //, visit: fn (UnsafePointer[RawTreeNode[origin]])
+](node: UnsafePointer[RawTreeNode[origin]]):
+    if not node:
+        return
+    for_each[visit](node[].left)
+    visit(node)
+    for_each[visit](node[].right)
+
+
+fn _find[
+    origin: ImmutableOrigin, //
+](node: UnsafePointer[RawTreeNode[origin]], key: String) -> __type_of(node):
+    if not node or node[].key == key:
+        return node
+
+    if node[].key < key:
+        return _find(node[].right, key)
+    return _find(node[].left, key)
+
+
+fn _get_left_most[
+    origin: ImmutableOrigin, //
+](owned node: UnsafePointer[RawTreeNode[origin]]) -> __type_of(node):
+    while node[].left:
+        node = node[].left
+    return node
+
+
+fn _get_next[
+    origin: ImmutableOrigin, //
+](owned node: UnsafePointer[RawTreeNode[origin]]) -> __type_of(node):
+    if node[].right:
+        return _get_left_most(node[].right)
+    while node[].parent and node == node[].parent[].right:
+        node = node[].parent
+    return node[].parent

--- a/emberjson/lazy/raw_value.mojo
+++ b/emberjson/lazy/raw_value.mojo
@@ -1,0 +1,421 @@
+from python import PythonObject
+from memory import UnsafePointer, memcmp
+from os import abort
+from utils import Variant
+
+
+from .raw_object import RawObject
+from .raw_array import RawArray
+from emberjson.format_int import write_int
+from emberjson.teju import write_f64
+from emberjson.parser import Parser
+from emberjson._parser_helper import copy_to_string, TRUE
+from emberjson.traits import JsonValue
+
+
+struct RawJsonType(Copyable, Movable):
+    alias OBJECT = RawJsonType.__init__[0]()
+    alias ARRAY = RawJsonType.__init__[1]()
+    alias INT = RawJsonType.__init__[2]()
+    alias FLOAT = RawJsonType.__init__[3]()
+    alias FLOAT_DOT = RawJsonType.__init__[4]()
+    alias FLOAT_EXP = RawJsonType.__init__[5]()
+    alias STRING = RawJsonType.__init__[6]()
+    alias BOOL = RawJsonType.__init__[7]()
+    alias TRUE = RawJsonType.__init__[8]()
+    alias FALSE = RawJsonType.__init__[9]()
+    alias NULL = RawJsonType.__init__[10]()
+    var _type: UInt8
+
+    @always_inline
+    fn __init__[json_type: UInt8](out self):
+        constrained[UInt8(0) <= json_type <= UInt8(10), "Invalid type"]()
+        self._type = json_type
+
+    @always_inline
+    fn __is__(self, other: Self) -> Bool:
+        return self._type == other._type
+
+    @always_inline
+    fn __is_not__(self, other: Self) -> Bool:
+        return self._type != other._type
+
+    @always_inline
+    fn __eq__(self, other: Self) -> Bool:
+        return self._type == other._type
+
+    @always_inline
+    fn __ne__(self, other: Self) -> Bool:
+        return self._type != other._type
+
+
+@value
+struct RawValue[origin: ImmutableOrigin](JsonValue):
+    var _type: RawJsonType
+    var _data: Variant[Span[Byte, origin], RawObject[origin], RawArray[origin]]
+
+    @always_inline
+    fn __init__(out self):
+        self._type = RawJsonType.NULL
+        self._data = Span[Byte, origin]()
+
+    @implicit
+    @always_inline
+    fn __init__(
+        out self: RawValue[StaticConstantOrigin], n: NoneType._mlir_type
+    ):
+        self = __type_of(self)()
+
+    @implicit
+    @always_inline
+    fn __init__(out self, val: Bool):
+        if val:
+            self._type = RawJsonType.TRUE
+            self._data = "true".as_bytes()
+        else:
+            self._type = RawJsonType.FALSE
+            self._data = "false".as_bytes()
+
+    @implicit
+    @always_inline
+    fn __init__(out self: RawValue[StaticConstantOrigin], val: StringLiteral):
+        self._type = RawJsonType.STRING
+        self._data = val.as_bytes()
+
+    @implicit
+    @always_inline
+    fn __init__(out self, val: StringSlice[origin]):
+        self._type = RawJsonType.STRING
+        self._data = val.as_bytes()
+
+    @implicit
+    @always_inline
+    fn __init__(out self, ref [origin]val: String):
+        self._type = RawJsonType.STRING
+        self._data = val.as_bytes()
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned val: RawObject[origin]):
+        self._type = RawJsonType.OBJECT
+        self._data = val^
+
+    @implicit
+    @always_inline
+    fn __init__(out self, owned val: RawArray[origin]):
+        self._type = RawJsonType.ARRAY
+        self._data = val^
+
+    @always_inline
+    fn __init__(out self, *, json_type: RawJsonType, span: Span[Byte, origin]):
+        self._type = json_type
+        self._data = span
+
+    @always_inline
+    fn __init__(out self, *, parse_string: StringSlice[origin]) raises:
+        var p = RawParser(parse_string)
+        self = p.parse_value()
+
+    @always_inline
+    fn copy(self) -> Self:
+        return self
+
+    fn __eq__(self, other: Self) -> Bool:
+        if self._type != other._type:
+            return False
+        if self.is_object():
+            debug_assert(
+                other._data.isa[RawObject[origin]](), "should be equal"
+            )
+            return (
+                self._data[RawObject[origin]] == other._data[RawObject[origin]]
+            )
+        elif self.is_array():
+            debug_assert(other._data.isa[RawArray[origin]](), "should be equal")
+            return self._data[RawArray[origin]] == other._data[RawArray[origin]]
+        var s_span = self._data[Span[Byte, origin]]
+        var o_span = other._data[Span[Byte, origin]]
+        if not s_span and not o_span:  # both empty
+            return True
+        if len(s_span) != len(o_span):
+            return False
+        return (
+            memcmp(s_span.unsafe_ptr(), o_span.unsafe_ptr(), len(s_span)) == 0
+        )
+
+    @always_inline
+    fn __ne__(self, other: Self) -> Bool:
+        return not self == other
+
+    fn __bool__(self) -> Bool:
+        try:
+            if self.is_int():
+                return Bool(self.int())
+            elif self.is_float():
+                return Bool(self.float())
+            elif self.is_string():
+                return Bool(self.as_string_slice())
+            elif self.is_true():
+                return True
+            elif self.is_false():
+                return False
+            elif self.is_bool():
+                return self.bool()
+            elif self.is_null():
+                return False
+            elif self.is_object():
+                return Bool(self.object())
+            elif self.is_array():
+                return Bool(self.array())
+            else:
+                return abort[Bool]("Unreachable: __bool__")
+        except:
+            return False
+
+    @always_inline
+    fn __as_bool__(self) -> Bool:
+        return Bool(self)
+
+    @always_inline
+    fn is_int(self) -> Bool:
+        return (
+            self._data.isa[Span[Byte, origin]]()
+            and self._type is RawJsonType.INT
+        )
+
+    @always_inline
+    fn is_string(self) -> Bool:
+        return (
+            self._data.isa[Span[Byte, origin]]()
+            and self._type is RawJsonType.STRING
+        )
+
+    @always_inline
+    fn is_true(self) -> Bool:
+        return (
+            self._data.isa[Span[Byte, origin]]()
+            and self._type is RawJsonType.TRUE
+        )
+
+    @always_inline
+    fn is_false(self) -> Bool:
+        return (
+            self._data.isa[Span[Byte, origin]]()
+            and self._type is RawJsonType.FALSE
+        )
+
+    @always_inline
+    fn is_bool(self) -> Bool:
+        return self._data.isa[Span[Byte, origin]]() and (
+            self._type is RawJsonType.BOOL
+            or self._type is RawJsonType.TRUE
+            or self._type is RawJsonType.FALSE
+        )
+
+    @always_inline
+    fn is_float(self) -> Bool:
+        return self._data.isa[Span[Byte, origin]]() and (
+            self._type is RawJsonType.FLOAT
+            or self._type is RawJsonType.FLOAT_DOT
+            or self._type is RawJsonType.FLOAT_EXP
+        )
+
+    @always_inline
+    fn is_object(self) -> Bool:
+        debug_assert(
+            self._data.isa[RawObject[origin]]()
+            == (self._type is RawJsonType.OBJECT),
+            "Both the variant and the RawJsonType should be equal",
+        )
+        return (
+            self._data.isa[RawObject[origin]]()
+            and self._type is RawJsonType.OBJECT
+        )
+
+    @always_inline
+    fn is_array(self) -> Bool:
+        debug_assert(
+            self._data.isa[RawArray[origin]]()
+            == (self._type is RawJsonType.ARRAY),
+            "Both the variant and the RawJsonType should be equal",
+        )
+        return (
+            self._data.isa[RawArray[origin]]()
+            and self._type is RawJsonType.ARRAY
+        )
+
+    @always_inline
+    fn is_null(self) -> Bool:
+        return (
+            self._data.isa[Span[Byte, origin]]()
+            and self._type is RawJsonType.NULL
+        )
+
+    @always_inline
+    fn null(self) raises -> None:
+        if not self.is_null():
+            raise Error("RawValue should be an null")
+        return None
+
+    @always_inline
+    fn string(ref self) raises -> String:
+        if not self.is_string():
+            raise Error("RawValue should be a string")
+        var span = self._data[Span[Byte, origin]]
+        var ptr = span.unsafe_ptr()
+        return copy_to_string(ptr, ptr + len(span))
+
+    @always_inline
+    fn as_string_slice(ref self) -> StringSlice[origin]:
+        """Returns a stringslice with the unparsed unicode escape sequences and
+        potentially invalid UTF-16 surrogate pairs."""
+        debug_assert(self.is_string(), "RawValue should be a string")
+        return StringSlice(unsafe_from_utf8=self._data[Span[Byte, origin]])
+
+    @always_inline
+    fn int(self) raises -> Int:
+        if not self.is_int():
+            raise Error("RawValue should be an int")
+        var p = Parser(self._data[Span[Byte, origin]])
+        return Int(p.parse_number().int())  # TODO: specialize for each
+
+    @always_inline
+    fn float(self) raises -> Float64:
+        if not self.is_float():
+            raise Error("RawValue should be a float")
+        var p = Parser(self._data[Span[Byte, origin]])
+        if self._type is RawJsonType.FLOAT_DOT:
+            return p.parse_number().float()  # TODO: specialize for each
+        elif self._type is RawJsonType.FLOAT_EXP:
+            return p.parse_number().float()  # TODO: specialize for each
+        else:
+            return p.parse_number().float()  # TODO: specialize for each
+
+    @always_inline
+    fn bool(self) raises -> Bool:
+        if not self.is_bool():
+            raise Error("RawValue should be a bool")
+        var span = self._data[Span[Byte, origin]]
+        if not (4 <= len(span) <= 5):
+            raise Error("Data is not the correct length")
+        return True if self._type is RawJsonType.TRUE else (
+            False if (self._type is RawJsonType.FALSE) else Bool(
+                span.unsafe_ptr().bitcast[UInt32]()[0] == TRUE
+            )
+        )
+
+    @always_inline
+    fn object(ref self) raises -> RawObject[origin]:
+        if not self.is_object():
+            raise Error("RawValue should be an object")
+        return self._data[RawObject[origin]]
+
+    @always_inline
+    fn array(ref self) raises -> RawArray[origin]:
+        if not self.is_array():
+            raise Error("RawValue should be an array")
+        return self._data[RawArray[origin]]
+
+    fn write_to[W: Writer](self, mut writer: W):
+        if self.is_object():
+            try:
+                writer.write(self.object())
+            except:
+                writer.write("{}")
+        elif self.is_array():
+            try:
+                writer.write(self.array())
+            except:
+                writer.write("[]")
+        else:
+            debug_assert(
+                self._data.isa[Span[Byte, origin]](),
+                "data should be a Span:",
+                self._type._type,
+            )
+            if self.is_string():
+                writer.write('"', self.as_string_slice(), '"')
+                return
+
+            var span = self._data[Span[Byte, origin]]
+            if span:
+                writer.write(StringSlice(unsafe_from_utf8=span))
+            else:
+                writer.write("null")
+
+    fn _pretty_to_as_element[
+        W: Writer
+    ](self, mut writer: W, indent: String, curr_depth: UInt):
+        if self.is_object():
+            writer.write("{\n")
+            try:
+                self.object()._pretty_write_items(
+                    writer, indent, curr_depth + 1
+                )
+            except:
+                pass
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write("}")
+        elif self.is_array():
+            writer.write("[\n")
+            try:
+                self.array()._pretty_write_items(writer, indent, curr_depth + 1)
+            except:
+                pass
+            for _ in range(curr_depth):
+                writer.write(indent)
+            writer.write("]")
+        else:
+            self.write_to(writer)
+
+    fn pretty_to[
+        W: Writer
+    ](self, mut writer: W, indent: String, *, curr_depth: UInt = 0):
+        if self.is_object():
+            var obj: RawObject[origin]
+            try:
+                obj = self.object()
+            except:
+                obj = RawObject[origin]()
+            obj.pretty_to(writer, indent, curr_depth=curr_depth)
+
+        elif self.is_array():
+            var arr: RawArray[origin]
+            try:
+                arr = self.array()
+            except:
+                arr = RawArray[origin]()
+            arr.pretty_to(writer, indent, curr_depth=curr_depth)
+
+        else:
+            self.write_to(writer)
+
+    @always_inline
+    fn __str__(self) -> String:
+        return write(self)
+
+    @always_inline
+    fn __repr__(self) -> String:
+        return self.__str__()
+
+    fn to_python_object(self) -> PythonObject:
+        try:
+            if self.is_int():
+                return self.int()
+            elif self.is_float():
+                return self.float()
+            elif self.is_string():
+                return self.string()
+            elif self.is_bool():
+                return self.bool()
+            elif self.is_null():
+                return None
+            elif self.is_object():
+                return self.object().to_python_object()
+            elif self.is_array():
+                return self.array().to_python_object()
+            else:
+                return abort[NoneType]("Unreachable: to_python_object")
+        except:
+            return None

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/bgreni/EmberJson"
 [tasks]
 build = { cmd = "mojo package emberjson -o emberjson.mojopkg" }
 format = { cmd = "mojo format -l 80 ." }
-test = { cmd = "mojo test -D ASSERT=all" }
+test = { cmd = "mojo test -D ASSERT=all -I ." }
 bench = { cmd = "mojo build bench.mojo && ./bench && rm bench" }
 update_and_build = { cmd = "pixi update && pixi run test && pixi run build" }
 precommit = { depends-on = ["format", "test"] }

--- a/test/emberjson/lazy/test_raw_array.mojo
+++ b/test/emberjson/lazy/test_raw_array.mojo
@@ -1,0 +1,161 @@
+from testing import assert_equal, assert_true, assert_false, assert_not_equal
+
+from emberjson import RawArray, RawObject, RawValue
+
+
+def test_array():
+    var s = '[ 1, 2, "foo" ]'
+    var arr = RawArray(parse_string=s)
+    assert_equal(len(arr), 3)
+    assert_equal(arr[0].int(), 1)
+    assert_equal(arr[1].int(), 2)
+    assert_equal(arr[2].string(), "foo")
+    assert_equal(String(arr), '[1,2,"foo"]')
+    arr[0] = RawValue(parse_string="10")
+    assert_equal(arr[0].int(), 10)
+
+
+def test_array_no_space():
+    var s = '[1,2,"foo"]'
+    var arr = RawArray(parse_string=s)
+    assert_equal(len(arr), 3)
+    assert_equal(arr[0].int(), 1)
+    assert_equal(arr[1].int(), 2)
+    assert_equal(arr[2].string(), "foo")
+
+
+def test_nested_object():
+    var s = '[false, null, [4.0], { "key": "bar" }]'
+    var arr = RawArray(parse_string=s)
+    assert_equal(len(arr), 4)
+    assert_equal(arr[0].bool(), False)
+    assert_equal(arr[1].null(), None)
+    var nested_arr = arr[2].array()
+    assert_equal(len(nested_arr), 1)
+    assert_equal(nested_arr[0].float(), 4.0)
+    var ob = arr[3].object()
+    assert_true("key" in ob)
+    assert_equal(ob["key"].string(), "bar")
+
+
+def test_contains():
+    var s = '[false, 123, "str"]'
+    var arr = RawArray(parse_string=s)
+    assert_true(False in arr)
+    assert_true(RawValue(parse_string="123") in arr)
+    assert_true("str" in arr)
+    assert_false(True in arr)
+    assert_true(True not in arr)
+
+
+def test_variadic_init():
+    var arr = RawArray(RawValue(parse_string="123"), "foo", None)
+    var ob = RawObject[StaticConstantOrigin]()
+    ob["key"] = "value"
+
+    var arr2 = RawArray(
+        RawValue(parse_string="45"),
+        RawValue(parse_string="45.5"),
+        RawValue(parse_string="45.5"),
+        RawValue(arr),
+        RawValue(ob),
+    )
+    assert_equal(arr[0].int(), 123)
+    assert_equal(arr[1].string(), "foo")
+    assert_equal(arr[2].null(), None)
+
+    assert_equal(arr2[0], RawValue(parse_string="45"))
+    assert_equal(arr2[1], RawValue(parse_string="45.5"))
+    assert_equal(arr2[2], RawValue(parse_string="45.5"))
+    assert_true(arr2[3].is_array())
+    assert_equal(arr2[3], arr)
+    assert_true(arr2[4].is_object())
+    assert_equal(arr2[4], ob)
+
+
+def test_equality():
+    var arr1 = RawArray(
+        RawValue(parse_string="123"), RawValue(parse_string="456")
+    )
+    var arr2 = RawArray(
+        RawValue(parse_string="123"), RawValue(parse_string="456")
+    )
+    var arr3 = RawArray(RawValue(parse_string="123"), "456")
+    assert_equal(arr1, arr2)
+    assert_not_equal(arr1, arr3)
+
+
+def test_list_ctr():
+    var arr = RawArray(
+        List[RawValue[StaticConstantOrigin]](
+            RawValue(parse_string="123"),
+            "foo",
+            RawValue(parse_string="null"),
+            RawValue(parse_string="false"),
+        )
+    )
+    assert_equal(arr[0].int(), 123)
+    assert_equal(arr[1].string(), "foo")
+    assert_equal(arr[2].null(), None)
+    assert_equal(arr[3].bool(), False)
+
+    assert_equal(
+        arr.to_list(),
+        List[RawValue[StaticConstantOrigin]](
+            RawValue(parse_string="123"),
+            "foo",
+            RawValue(parse_string="null"),
+            RawValue(parse_string="false"),
+        ),
+    )
+
+
+def test_iter():
+    var arr = RawArray(
+        RawValue(parse_string="false"),
+        RawValue(parse_string="123"),
+        RawValue(parse_string="null"),
+    )
+
+    var it = arr.__iter__()
+    var elt = it.__next__()
+    assert_equal(elt[], arr[0])
+    assert_equal(Bool(elt[]), False)
+    assert_true(it.__has_next__())
+    elt = it.__next__()
+    assert_equal(elt[], arr[1])
+    assert_equal(Bool(elt[]), True)
+    assert_true(it.__has_next__())
+    elt = it.__next__()
+    assert_equal(elt[], arr[2])
+    assert_equal(Bool(elt[]), False)
+
+    assert_equal(len(it), 0)
+    assert_false(it.__has_next__())
+
+    i = 2
+    for el in arr.reversed():
+        assert_equal(el[], arr[i])
+        i -= 1
+
+
+def test_list_literal():
+    var a: RawArray[StaticConstantOrigin] = [
+        RawValue(parse_string="123"),
+        RawValue(parse_string="435"),
+        False,
+        None,
+        RawValue(parse_string="12.32"),
+        "string",
+    ]
+    assert_equal(
+        a,
+        RawArray(
+            RawValue(parse_string="123"),
+            RawValue(parse_string="435"),
+            False,
+            None,
+            RawValue(parse_string="12.32"),
+            "string",
+        ),
+    )

--- a/test/emberjson/lazy/test_raw_object.mojo
+++ b/test/emberjson/lazy/test_raw_object.mojo
@@ -1,0 +1,139 @@
+from testing import assert_true, assert_equal, assert_raises, assert_not_equal
+
+from emberjson import RawObject, RawArray, RawValue
+
+
+def test_object():
+    var s = '{"thing":123}'
+    var ob = RawObject(parse_string=s)
+    assert_true("thing" in ob)
+    assert_equal(ob["thing"].int(), 123)
+    assert_equal(String(ob), s)
+
+
+def test_to_from_dict():
+    var d = Dict[String, RawValue[StaticConstantOrigin]]()
+    d["key"] = False
+
+    var o = RawObject(d^)
+    assert_equal(o["key"].bool(), False)
+
+    d = o.to_dict()
+    assert_equal(d["key"].bool(), False)
+
+
+def test_object_spaces():
+    var s = '{ "Key" : "some value" }'
+    var ob = RawObject(parse_string=s)
+    assert_true("Key" in ob)
+    assert_equal(ob["Key"].string(), "some value")
+
+
+def test_nested_object():
+    var s = '{"nested": { "foo": null } }"'
+    var ob = RawObject(parse_string=s)
+    assert_true("nested" in ob)
+    assert_true(ob["nested"].is_object())
+    assert_true(ob["nested"].object()["foo"].is_null())
+
+    with assert_raises():
+        _ = ob["DOES NOT EXIST"]
+
+
+def test_arr_in_object():
+    var s = '{"arr": [null, 2, "foo"]}'
+    var ob = RawObject(parse_string=s)
+    assert_true("arr" in ob)
+    assert_true(ob["arr"].is_array())
+    assert_equal(ob["arr"].array()[0].null(), None)
+    assert_equal(ob["arr"].array()[1].int(), 2)
+    assert_equal(ob["arr"].array()[2].string(), "foo")
+
+
+def test_multiple_keys():
+    var s = '{"k1": 123, "k2": 456}'
+    var ob = RawObject(parse_string=s)
+    assert_true("k1" in ob)
+    assert_true("k2" in ob)
+    assert_equal(ob["k1"].int(), 123)
+    assert_equal(ob["k2"].int(), 456)
+    assert_equal(String(ob), '{"k1":123,"k2":456}')
+
+
+def test_invalid_key():
+    var s = "{key: 123}"
+    with assert_raises():
+        _ = RawObject(parse_string=s)
+
+
+def test_single_quote_identifier():
+    var s = "'key': 123"
+    with assert_raises():
+        _ = RawObject(parse_string=s)
+
+
+def test_single_quote_value():
+    var s = "\"key\": '123'"
+    with assert_raises():
+        _ = RawObject(parse_string=s)
+
+
+def test_equality():
+    var ob1 = RawObject[StaticConstantOrigin]()
+    ob1["key"] = RawValue(parse_string="123")
+    var ob2 = ob1
+    var ob3 = ob1
+    ob3["key"] = None
+
+    assert_equal(ob1, ob2)
+    assert_not_equal(ob1, ob3)
+
+
+def test_bad_value():
+    with assert_raises():
+        _ = RawObject(parse_string='{"key": nil}')
+
+
+def test_write():
+    var ob = RawObject[StaticConstantOrigin]()
+    ob["foo"] = "stuff"
+    ob["bar"] = RawValue(parse_string="123")
+    assert_equal(String(ob), '{"bar":123,"foo":"stuff"}')
+
+
+def test_iter():
+    var ob = RawObject[StaticConstantOrigin]()
+    ob["a"] = "stuff"
+    ob["b"] = RawValue(parse_string="123")
+    ob["c"] = RawValue(parse_string="3.423")
+
+    var keys = List[String]("a", "b", "c")
+
+    var i = 0
+    for el in ob.keys():
+        assert_equal(el[], keys[i])
+        i += 1
+
+    i = 0
+    # check that the default is to iterate over keys
+    for el in ob:
+        assert_equal(el[], keys[i])
+        i += 1
+
+    var values = List[RawValue[StaticConstantOrigin]](
+        "stuff", RawValue(parse_string="123"), RawValue(parse_string="3.423")
+    )
+
+    i = 0
+    for el in ob.values():
+        assert_equal(el[], values[i])
+        i += 1
+
+    def test_dict_literal():
+        var o: RawObject[StaticConstantOrigin] = {
+            "key": RawValue(parse_string="1234"),
+            "key2": False,
+        }
+
+        assert_equal(o["key"].int(), 1234)
+        assert_equal(o["key2"].bool(), False)

--- a/test/emberjson/lazy/test_raw_parser.mojo
+++ b/test/emberjson/lazy/test_raw_parser.mojo
@@ -1,0 +1,67 @@
+from testing import assert_true, assert_equal, assert_raises
+
+from emberjson import RawJsonType, RawParser, RawJSON, RawArray, RawObject
+
+
+def test_parse():
+    var s = '{"key": 123}'
+    var p = RawParser(s)
+    var json = p.parse()
+    assert_true(json.is_object())
+    assert_equal(json.object()["key"].int(), 123)
+    assert_equal(json.object()["key"].int(), 123)
+    assert_equal(String(json), '{"key":123}')
+    assert_equal(len(json), 1)
+
+
+def test_parse_utf16_surrogates():
+    var s = r'{"key": "To decode U+10437 (\uD801\uDC37) from UTF-16:"}'
+    var p = RawParser(s)
+    var json = p.parse()
+    assert_true(json.is_object())
+    assert_true(json.object()["key"].is_string())
+    assert_equal(
+        json.object()["key"].string(), "To decode U+10437 (𐐷) from UTF-16:"
+    )
+
+    var s2 = r'{"\uD801\uDC37": "\uD801\uDC37"}'
+    var p2 = RawParser(s2)
+    var json2 = p2.parse()
+    assert_true(json2.is_object())
+    assert_true(json2.object()["𐐷"].is_string())
+    assert_equal(json2.object()["𐐷"].string(), "𐐷")
+
+
+def test_parse_wrong_backslash():
+    var data = List('{"key": "This should raise and not segfault:'.as_bytes())
+    data.append(Byte(ord("\\")))
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+    data.append(Byte(ord("u")))
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+    data.extend("D801".as_bytes())
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+    data.append(Byte(ord("\\")))
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+    data.append(Byte(ord("u")))
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+    data.extend("D801".as_bytes())
+    with assert_raises():
+        var p = RawParser(Span(data))
+        _ = p.parse()
+
+    var data2 = List('{"key": '.as_bytes())
+    data2.append(Byte(ord("\\")))
+    data2.extend('"this should not be correct"}'.as_bytes())
+    var p2 = RawParser(Span(data2))
+    with assert_raises():
+        _ = p2.parse()

--- a/test/emberjson/lazy/test_raw_value.mojo
+++ b/test/emberjson/lazy/test_raw_value.mojo
@@ -1,0 +1,219 @@
+from emberjson import RawValue, RawObject, RawArray, write_pretty
+from testing import (
+    assert_equal,
+    assert_true,
+    assert_raises,
+    assert_not_equal,
+    assert_almost_equal,
+    assert_false,
+)
+
+
+def test_bool():
+    var s: String = "false"
+    var v = RawValue(parse_string=s)
+    assert_true(v.is_bool())
+    assert_equal(v.bool(), False)
+    assert_equal(String(v), s)
+
+    s = "true"
+    v = RawValue(parse_string=s)
+    assert_true(v.is_bool())
+    assert_equal(v.bool(), True)
+    assert_equal(String(v), s)
+    assert_true(v.is_bool())
+
+
+def test_string():
+    var s: String = '"Some String"'
+    var v = RawValue(parse_string=s)
+    assert_true(v.is_string())
+    assert_equal(v.string(), "Some String")
+    assert_equal(String(v), s)
+
+    s = r"\uD801\uDC37"
+    v = RawValue(s)
+    assert_true(v.is_string())
+    assert_equal(v.string(), "𐐷")
+    assert_equal(v.as_string_slice(), s)
+    assert_true(v.is_string())
+
+    # check short string
+    s = '"s"'
+    v = RawValue(parse_string=s)
+    assert_equal(v.string(), "s")
+    assert_equal(String(v), s)
+
+    with assert_raises():
+        _ = RawValue(parse_string=r"Invalid unicode \u123z escape").string()
+
+    with assert_raises():
+        _ = RawValue(parse_string=r"Another invalid \uXYZG escape").string()
+
+    with assert_raises():
+        _ = RawValue(parse_string=r"Wrong format \u12Z4 escape").string()
+
+    with assert_raises():
+        _ = RawValue(parse_string=r"Wrong format \uFFFF escape").string()
+
+    with assert_raises():
+        _ = RawValue(parse_string=r"Incomplete escape \u12 escape").string()
+
+
+def test_null():
+    var s: String = "null"
+    var v = RawValue(parse_string=s)
+    assert_true(v.is_null())
+    assert_equal(String(v), s)
+
+    assert_true(RawValue(None).is_null())
+
+    with assert_raises():
+        _ = RawValue(parse_string="nil")
+
+
+def test_integer():
+    var v = RawValue(parse_string="123")
+    assert_true(v.is_int())
+    assert_equal(v.int(), 123)
+    assert_equal(String(v), "123")
+    assert_true(v.is_int())
+
+
+def test_integer_leading_plus():
+    var v = RawValue(parse_string="+123")
+    assert_true(v.is_int())
+    assert_equal(v.int(), 123)
+
+
+def test_integer_negative():
+    var v = RawValue(parse_string="-123")
+    assert_true(v.is_int())
+    assert_equal(v.int(), -123)
+    assert_equal(String(v), "-123")
+
+
+def test_float():
+    var v = RawValue(parse_string="43.5")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), 43.5)
+    assert_equal(String(v), "43.5")
+
+
+def test_eight_digits_after_dot():
+    var v = RawValue(parse_string="342.12345678")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), 342.12345678)
+    assert_equal(String(v), "342.12345678")
+
+
+def test_special_case_floats():
+    var v = RawValue(parse_string="2.2250738585072013e-308")
+    assert_almost_equal(v.float(), 2.2250738585072013e-308)
+    assert_true(v.is_float())
+
+    var v2 = RawValue(parse_string="7.2057594037927933e+16")
+    assert_true(v2.is_float())
+    assert_almost_equal(v2.float(), 7.2057594037927933e16)
+
+    var v3 = RawValue(parse_string="1e000000000000000000001")
+    assert_true(v3.is_float())
+    assert_almost_equal(v3.float(), 1e000000000000000000001)
+
+    var v4 = RawValue(
+        parse_string="3.1415926535897932384626433832795028841971693993751"
+    )
+    assert_true(v4.is_float())
+    assert_almost_equal(
+        v4.float(), 3.1415926535897932384626433832795028841971693993751
+    )
+
+    with assert_raises():
+        # This is "infinite"
+        _ = RawValue(
+            parse_string="10000000000000000000000000000000000000000000e+308"
+        ).float()
+
+    var v5 = RawValue(parse_string=String(Float64.MAX_FINITE))
+    assert_equal(v5.float(), Float64.MAX_FINITE)
+
+    var v6 = RawValue(parse_string=String(Float64.MIN_FINITE))
+    assert_equal(v6.float(), Float64.MIN_FINITE)
+
+
+def test_float_leading_plus():
+    var v = RawValue(parse_string="+43.5")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), 43.5)
+
+
+def test_float_negative():
+    var v = RawValue(parse_string="-43.5")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), -43.5)
+
+
+def test_float_exponent():
+    var v = RawValue(parse_string="43.5e10")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), 43.5e10)
+
+
+def test_float_exponent_negative():
+    var v = RawValue(parse_string="-43.5e10")
+    assert_true(v.is_float())
+    assert_almost_equal(v.float(), -43.5e10)
+
+
+def test_equality():
+    var s = "34"
+    var v1 = RawValue(parse_string=s)
+    var v2 = RawValue("Some string")
+    var v3 = RawValue("Some string")
+    assert_equal(v2, v3)
+    assert_not_equal(v1, v2)
+
+    def eq_self(v: RawValue):
+        assert_equal(v, v)
+
+    eq_self(RawValue(parse_string="123"))
+    eq_self(RawValue(parse_string="34.5"))
+    eq_self(RawValue(parse_string="null"))
+    eq_self(RawValue(parse_string="false"))
+    eq_self(RawValue(RawArray[StaticConstantOrigin]()))
+    eq_self(RawValue(RawObject[StaticConstantOrigin]()))
+
+
+def test_pretty():
+    var v = RawValue(parse_string="[123, 43564, false]")
+    var expected: String = """[
+    123,
+    43564,
+    false
+]"""
+    assert_equal(expected, write_pretty(v))
+
+    v = RawValue(parse_string='{"key": 123, "k2": null}')
+    expected = """{
+    "k2": null,
+    "key": 123
+}"""
+
+    assert_equal(expected, write_pretty(v))
+
+
+def test_booling():
+    var a = RawValue(parse_string="true")
+    assert_true(a)
+    if not a:
+        raise Error("Implicit bool failed")
+
+    var trues = RawArray(parse_string='["some string", 123, 3.43]')
+    var i = 0
+    for t in trues:
+        i += 1
+        assert_true(t[])
+
+    var falsies = RawArray(parse_string='["", 0, 0.0, false, null, null]')
+    for f in falsies:
+        assert_false(f[])


### PR DESCRIPTION
Add Raw types and tests (lazy parsing). Closes #33.

This will most likely have lower performance for parsing the complete json, but they might have better perf for nested structures where the user only accesses some of them. It might be faster for json containing a lot of integers and floats though once we add specialized functions for their parsing making use of the previous pass that determines which subtype they are.

This also uses `Span[Byte]` and an index instead of `CheckedPointer`