### PR TITLE
fix: remove explicit bound parameter from pack_into_integer.

### DIFF
--- a/emberjson/_parser_helper.mojo
+++ b/emberjson/_parser_helper.mojo
@@ -55,12 +55,11 @@ alias Bits_T = Scalar[_uint(SIMD8_WIDTH)]
 @always_inline
 fn get_non_space_bits(s: SIMD8xT) -> Bits_T:
     var vec = s.eq(` `) | s.eq(`\n`) | s.eq(`\t`) | s.eq(`\r`)
-    return ~pack_into_integer[SIMD8xT.size](vec)
+    return ~pack_into_integer(vec)
 
 
-# FIXME: Remove the explicit size parameter once https://github.com/modular/modular/issues/5164 is fixed
 @always_inline
-fn pack_into_integer[size: Int](simd: SIMDBool[size]) -> Bits_T:
+fn pack_into_integer(simd: SIMDBool) -> Bits_T:
     return Bits_T(pack_bits(simd))
 
 

--- a/emberjson/parser.mojo
+++ b/emberjson/parser.mojo
@@ -649,7 +649,7 @@ fn minify(s: String, out out_str: String) raises:
         else:
             var chunk = _load_chunk(ptr, is_block_iter)
 
-            var quotes = pack_into_integer[chunk.size](chunk == `"`)
+            var quotes = pack_into_integer(chunk.eq(`"`))
             var valid_bits = count_trailing_zeros(~get_non_space_bits(chunk))
             if quotes != 0:
                 valid_bits = min(valid_bits, count_trailing_zeros(quotes))


### PR DESCRIPTION
- The bug was caused by `==` turning the SIMD into a Scalar. When we switched to `eq` we ended up also fixing this.
- https://github.com/modular/modular/issues/5164 and https://github.com/modular/modular/issues/5164#issuecomment-3192703822