### PR TITLE
fix: remove run_destructors from StackArray since InlineArray no longer supports it.

### DIFF
--- a/emberjson/utils.mojo
+++ b/emberjson/utils.mojo
@@ -120,7 +120,7 @@ struct CheckedPointer(Comparable, Copyable):
 
 alias DefaultPrettyIndent = 4
 
-alias StackArray = InlineArray[_, _, run_destructors=False]
+alias StackArray = InlineArray[_, _]
 
 
 @always_inline

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,7 @@ update_and_test = "pixi update && pixi run test && pixi run bench"
 test_python_compat = "python python_compat.py"
 
 [dependencies]
-mojo = ">=25.6.0.dev2025080305,<26"
+mojo = ">=25.6.0.dev202508250,<26"
 
 
 


### PR DESCRIPTION
bump: update mojo version to 25.6.0.dev202508250

Reference: https://github.com/modular/modular/commit/8a5448b6e53fd6fc7023e9dd3489c2d7b22c11da

Note for @bgreni The doc commit says:
```
- `InlineArray` now automatically detects whether its element types are
  trivially destructible to not invoke the destructors in its `__del__`
  function.  This improves performance for trivially destructible types
  (such as `Int` and friends).
```
